### PR TITLE
add variant temp table and deployment action

### DIFF
--- a/.github/workflows/deploy-app-db.yml
+++ b/.github/workflows/deploy-app-db.yml
@@ -1,0 +1,54 @@
+name: Deploy DACPAC
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ dev, main ]
+    # Only trigger the workflow if changes occur in the 'Application.Database' folder (including all subfolders and files)
+    paths:
+      - 'Application.Database/**'
+      
+  
+
+jobs:
+  build-and-deploy-db:
+    # Run on your self-hosted Windows runner in Azure VM
+    runs-on: gmrldw
+    # If your self-hosted runner has specific labels, do something like:
+    # runs-on: [self-hosted, windows, azure-vm]
+
+    # Dynamically pick environment: if branch is 'dev', use 'test'; else use 'prod'
+    environment: ${{ github.ref_name == 'dev' && 'test' || 'prod' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      # 1. BUILD THE DACPAC (if your .sqlproj is in the repo)
+      - name: Build the DACPAC project (cmd shell)
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" Application.Database/Application.Database.sqlproj /t:Build /p:Configuration=Release
+
+
+      # 2. DEPLOY/PUBLISH THE DACPAC
+      - name: Publish DACPAC to SQL Database
+        run: |
+          # Example using sqlpackage to publish the DACPAC
+          # Adjust the SourceFile path if your build output folder is different
+          sqlpackage /Action:Publish `
+            /SourceFile:"Application.Database\bin\Release\Application.Database.dacpac" `
+            /TargetServerName:"$Env:DB_SERVER" `
+            /TargetDatabaseName:"$Env:DB_NAME" `
+            /TargetUser:"$Env:DB_USER" `
+            /TargetPassword:"$Env:DB_PASS" `
+            /TargetTrustServerCertificate:True `
+            /TargetEncryptConnection:True `
+            /p:BlockOnPossibleDataLoss=false `
+            /p:DropObjectsNotInSource=false
+        shell: powershell
+        env:
+          DB_SERVER: ${{ secrets.FLOWBYTE_DB_SERVER }}
+          DB_NAME: ${{ secrets.FLOWBYTE_DB }}
+          DB_USER: ${{ secrets.FLOWBYTE_DB_USER }}
+          DB_PASS: ${{ secrets.FLOWBYTE_DB_PASSWORD }}

--- a/Application.Database/Application.Database.sqlproj
+++ b/Application.Database/Application.Database.sqlproj
@@ -166,5 +166,8 @@
     <Build Include="Storage\FLOWBYTE_SALES.sql" />
     <Build Include="Security\fb.sql" />
     <Build Include="Security\tmp.sql" />
+    <Build Include="tmp\Tables\variant_temp.sql">
+      <AnsiNulls>Off</AnsiNulls>
+    </Build>
   </ItemGroup>
 </Project>

--- a/Application.Database/tmp/Tables/variant_temp.sql
+++ b/Application.Database/tmp/Tables/variant_temp.sql
@@ -1,0 +1,20 @@
+﻿CREATE TABLE [tmp].[variant_temp] (
+    [cdc_key]            BIGINT           NULL,
+    [company_id]         NVARCHAR (10)    NOT NULL,
+    [item_no]            NVARCHAR (255)   NOT NULL,
+    [variant_code]       NVARCHAR (255)   NOT NULL,
+    [description]        NVARCHAR (255)   NULL,
+    [status]             INT              NOT NULL,
+    [option_1]           NVARCHAR (255)   NULL,
+    [value_1]            NVARCHAR (255)   NULL,
+    [option_2]           NVARCHAR (255)   NULL,
+    [value_2]            NVARCHAR (255)   NULL,
+    [option_3]           NVARCHAR (255)   NULL,
+    [value_3]            NVARCHAR (255)   NULL,
+    [packaging_material] INT              NULL,
+    [width]              DECIMAL (38, 20) NULL,
+    [height]             DECIMAL (38, 20) NULL,
+    [depth]              DECIMAL (38, 20) NULL,
+    CONSTRAINT [PK_variant] PRIMARY KEY CLUSTERED ([company_id] ASC, [item_no] ASC, [variant_code] ASC)
+);
+


### PR DESCRIPTION
This pull request includes changes to automate the deployment of the database and adds a new temporary table to the database project. The most important changes include the creation of a GitHub Actions workflow for deploying the database and the addition of a new SQL table definition.

Automation and deployment:

* [`.github/workflows/deploy-app-db.yml`](diffhunk://#diff-9ed11fc9db10d798ba8f7d76386ddce6fa8332be1df320b49dee140a46a9fed8R1-R54): Added a new GitHub Actions workflow to automate the deployment of the database. The workflow is triggered on pushes to `dev` and `main` branches and includes steps to build and deploy the DACPAC file.

Database schema changes:

* [`Application.Database/Application.Database.sqlproj`](diffhunk://#diff-2dcee49040875a83d3450c0379e4984e1aa10073dce8f0389169da7cd2eb6dc0R169-R171): Included a new SQL file `tmp/Tables/variant_temp.sql` in the project build configuration.
* [`Application.Database/tmp/Tables/variant_temp.sql`](diffhunk://#diff-45a0e4471a5dbd60fcdbe6751e2eaa8953ec879780661c2de8561685c30e6c41R1-R20): Created a new table `variant_temp` with various columns and a primary key constraint.