### PR TITLE
fk: update foreign keys

### DIFF
--- a/Application.Database/data/Tables/dataset.sql
+++ b/Application.Database/data/Tables/dataset.sql
@@ -9,6 +9,6 @@
 	[created_on]       DATETIME NOT NULL,
 
     CONSTRAINT [PK_dataset] PRIMARY KEY ([id], [workspace_id], [application]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_dataset_table] FOREIGN KEY ([workspace_id],[application]) REFERENCES [data].[workspace]([id], [application])
+	CONSTRAINT [FK_dataset_workspace] FOREIGN KEY ([workspace_id],[application]) REFERENCES [data].[workspace]([id], [application])
 
 ) ON [FLOWBYTE_DIM];

--- a/Application.Database/data/Tables/dataset_user.sql
+++ b/Application.Database/data/Tables/dataset_user.sql
@@ -9,6 +9,6 @@
 	[role]             NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_dataset_user] PRIMARY KEY ([workspace_id], [application], [dataset_id], [e-mail]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_dataset_user_table] FOREIGN KEY ([workspace_id], [application], [dataset_id]) REFERENCES [data].[dataset]([id], [workspace_id], [application])
+	CONSTRAINT [FK_dataset_user_dataset] FOREIGN KEY ([dataset_id], [workspace_id], [application]) REFERENCES [data].[dataset]([id], [workspace_id], [application])
 
 ) ON [FLOWBYTE_DIM];

--- a/Application.Database/data/Tables/report.sql
+++ b/Application.Database/data/Tables/report.sql
@@ -9,6 +9,6 @@
     [dataset_id]       NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_report] PRIMARY KEY ([id], [workspace_id], [application]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_report_table] FOREIGN KEY ([workspace_id],[application]) REFERENCES [data].[dataset]([workspace_id], [application])
+	CONSTRAINT [FK_report_dataset] FOREIGN KEY ([dataset_id], [workspace_id],[application]) REFERENCES [data].[dataset]([id], [workspace_id], [application])
 
 ) ON [FLOWBYTE_DIM];

--- a/Application.Database/data/Tables/report_user.sql
+++ b/Application.Database/data/Tables/report_user.sql
@@ -9,6 +9,6 @@
 	[role]             NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_report_user] PRIMARY KEY ([workspace_id], [application], [report_id], [e-mail]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_report_user_table] FOREIGN KEY ([workspace_id], [application], [report_id]) REFERENCES [data].[report]([id], [workspace_id], [application])
+	CONSTRAINT [FK_report_user_report] FOREIGN KEY ([workspace_id], [application], [report_id]) REFERENCES [data].[report]([id], [workspace_id], [application])
 
 ) ON [FLOWBYTE_DIM];

--- a/Application.Database/data/Tables/workspace_user.sql
+++ b/Application.Database/data/Tables/workspace_user.sql
@@ -8,6 +8,6 @@
 	[role]             NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_workspace_user] PRIMARY KEY ([workspace_id], [application], [e-mail]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_workspace_user_table] FOREIGN KEY ([workspace_id],[application]) REFERENCES [data].[workspace]([id], [application])
+	CONSTRAINT [FK_workspace_user_workspace] FOREIGN KEY ([workspace_id],[application]) REFERENCES [data].[workspace]([id], [application])
 
 ) ON [FLOWBYTE_DIM];


### PR DESCRIPTION
This pull request updates foreign key constraint names across several database table definitions to improve clarity and consistency. The changes ensure that the naming conventions better reflect the relationships between tables.

### Foreign Key Constraint Renaming:

* [`Application.Database/data/Tables/dataset.sql`](diffhunk://#diff-0cb332a7ec7b863dcac113ec788bc850b47f659a8a26976b15e9fa53b588f48dL12-R12): Renamed the foreign key constraint from `FK_dataset_table` to `FK_dataset_workspace` for the `workspace_id` and `application` fields referencing the `workspace` table.
* [`Application.Database/data/Tables/dataset_user.sql`](diffhunk://#diff-c63057ceac785ab464ce2c18da38368bb933bac3b6e7f5d534507f8dd3bd39e3L12-R12): Renamed the foreign key constraint from `FK_dataset_user_table` to `FK_dataset_user_dataset` for the `dataset_id`, `workspace_id`, and `application` fields referencing the `dataset` table.
* [`Application.Database/data/Tables/report.sql`](diffhunk://#diff-7178f07247f055a235f57fdae606fa6a99b15d5820e83587f87bdfdbb8b8d300L12-R12): Renamed the foreign key constraint from `FK_report_table` to `FK_report_dataset` for the `dataset_id`, `workspace_id`, and `application` fields referencing the `dataset` table.
* [`Application.Database/data/Tables/report_user.sql`](diffhunk://#diff-7cd437ef1e1702e5889d756191d0c6b640627b7d12830c7b8347b6d9f817cadeL12-R12): Renamed the foreign key constraint from `FK_report_user_table` to `FK_report_user_report` for the `report_id`, `workspace_id`, and `application` fields referencing the `report` table.
* [`Application.Database/data/Tables/workspace_user.sql`](diffhunk://#diff-40f3f1af2a0ad916910c3a55bf5bf97b553cd28e0a9961b9396dbdf1ad195164L11-R11): Renamed the foreign key constraint from `FK_workspace_user_table` to `FK_workspace_user_workspace` for the `workspace_id` and `application` fields referencing the `workspace` table.