### PR TITLE
columns: update columns type

### DIFF
--- a/Application.Database/data/Tables/dataset_user.sql
+++ b/Application.Database/data/Tables/dataset_user.sql
@@ -3,7 +3,7 @@
 	[workspace_id]     NVARCHAR(500) NOT NULL,
 	[application]      NVARCHAR(500) NOT NULL,
 	[dataset_id]       NVARCHAR(500) NOT NULL,
-	[e-mail]           NVARCHAR(MAX) NOT NULL,
+	[e-mail]           NVARCHAR(500) NOT NULL,
 	[type]             NVARCHAR(500) NOT NULL,
 	[name]             NVARCHAR(500) NOT NULL,
 	[role]             NVARCHAR(500) NOT NULL,

--- a/Application.Database/data/Tables/report_user.sql
+++ b/Application.Database/data/Tables/report_user.sql
@@ -3,7 +3,7 @@
 	[workspace_id]     NVARCHAR(500) NOT NULL,
 	[application]      NVARCHAR(500) NOT NULL,
 	[report_id]        NVARCHAR(500) NOT NULL,
-	[e-mail]           NVARCHAR(MAX) NOT NULL,
+	[e-mail]           NVARCHAR(500) NOT NULL,
 	[user_type]        NVARCHAR(500) NOT NULL,
 	[name]             NVARCHAR(500) NOT NULL,
 	[role]             NVARCHAR(500) NOT NULL,

--- a/Application.Database/data/Tables/workspace_user.sql
+++ b/Application.Database/data/Tables/workspace_user.sql
@@ -2,7 +2,7 @@
 (
 	[workspace_id]     NVARCHAR(500) NOT NULL,
 	[application]      NVARCHAR(500) NOT NULL,
-	[e-mail]           NVARCHAR(MAX) NOT NULL,
+	[e-mail]           NVARCHAR(500) NOT NULL,
 	[user_type]        NVARCHAR(500) NOT NULL,
 	[name]             NVARCHAR(500) NOT NULL,
 	[role]             NVARCHAR(500) NOT NULL,


### PR DESCRIPTION
This pull request standardizes the column size for the `[e-mail]` field across multiple database tables by changing its type from `NVARCHAR(MAX)` to `NVARCHAR(500)`. This change ensures consistency and enforces a defined maximum length for email addresses.

Database schema updates:

* [`Application.Database/data/Tables/dataset_user.sql`](diffhunk://#diff-c63057ceac785ab464ce2c18da38368bb933bac3b6e7f5d534507f8dd3bd39e3L6-R6): Updated the `[e-mail]` column to `NVARCHAR(500)` to define a maximum length for email addresses.
* [`Application.Database/data/Tables/report_user.sql`](diffhunk://#diff-7cd437ef1e1702e5889d756191d0c6b640627b7d12830c7b8347b6d9f817cadeL6-R6): Changed the `[e-mail]` column type to `NVARCHAR(500)` for consistency with other tables.
* [`Application.Database/data/Tables/workspace_user.sql`](diffhunk://#diff-40f3f1af2a0ad916910c3a55bf5bf97b553cd28e0a9961b9396dbdf1ad195164L5-R5): Modified the `[e-mail]` column to use `NVARCHAR(500)` to enforce a consistent maximum length.