### PR TITLE
v0.5.1

### DIFF
--- a/Application.Database/data/Tables/report_user.sql
+++ b/Application.Database/data/Tables/report_user.sql
@@ -9,6 +9,6 @@
 	[role]             NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_report_user] PRIMARY KEY ([workspace_id], [application], [report_id], [e-mail]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_report_user_report] FOREIGN KEY ([workspace_id], [application], [report_id]) REFERENCES [data].[report]([workspace_id], [application], [id])
+	CONSTRAINT [FK_report_user_report] FOREIGN KEY ([report_id], [workspace_id], [application]) REFERENCES [data].[report]([id], [workspace_id], [application])
 
 ) ON [FLOWBYTE_DIM];

--- a/Application.Database/data/Tables/report_user.sql
+++ b/Application.Database/data/Tables/report_user.sql
@@ -9,6 +9,6 @@
 	[role]             NVARCHAR(500) NOT NULL,
 
     CONSTRAINT [PK_report_user] PRIMARY KEY ([workspace_id], [application], [report_id], [e-mail]) ON [FLOWBYTE_DIM],
-	CONSTRAINT [FK_report_user_report] FOREIGN KEY ([workspace_id], [application], [report_id]) REFERENCES [data].[report]([id], [workspace_id], [application])
+	CONSTRAINT [FK_report_user_report] FOREIGN KEY ([workspace_id], [application], [report_id]) REFERENCES [data].[report]([workspace_id], [application], [id])
 
 ) ON [FLOWBYTE_DIM];


### PR DESCRIPTION
This pull request includes a small but important change to the `report_user.sql` file. The change modifies the order of columns in the foreign key constraint `FK_report_user_report` to ensure consistency with the referenced table's column order.

* [`Application.Database/data/Tables/report_user.sql`](diffhunk://#diff-7cd437ef1e1702e5889d756191d0c6b640627b7d12830c7b8347b6d9f817cadeL12-R12): Updated the `FK_report_user_report` foreign key constraint to reference columns in the correct order (`[report_id], [workspace_id], [application]`) for alignment with the `[data].[report]` table.